### PR TITLE
feat: add (*Bot).OnAnyEvent

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -55,3 +55,32 @@ const (
 	// UserGroupAdminRemoved グループ管理者削除イベント
 	UserGroupAdminRemoved = "USER_GROUP_ADMIN_REMOVED"
 )
+
+var AllEvents = []string{
+	Error,
+	Ping,
+	Joined,
+	Left,
+	MessageCreated,
+	MessageUpdated,
+	MessageDeleted,
+	BotMessageStampsUpdated,
+	DirectMessageCreated,
+	DirectMessageUpdated,
+	DirectMessageDeleted,
+	ChannelCreated,
+	ChannelTopicChanged,
+	UserCreated,
+	UserActivated,
+	StampCreated,
+	TagAdded,
+	TagRemoved,
+	UserGroupCreated,
+	UserGroupUpdated,
+	UserGroupDeleted,
+	UserGroupMemberAdded,
+	UserGroupMemberUpdated,
+	UserGroupMemberRemoved,
+	UserGroupAdminAdded,
+	UserGroupAdminRemoved,
+}

--- a/handler.go
+++ b/handler.go
@@ -14,9 +14,18 @@ func (b *Bot) handleMultiCast(event string, raw json.RawMessage) {
 	}
 }
 
-// OnEvent 任意のイベントについてハンドラを登録します。
+// OnEvent 指定したイベントに対してハンドラを登録します。
 func (b *Bot) OnEvent(event string, h func(rawPayload json.RawMessage)) {
 	b.handlers[event] = append(b.handlers[event], h)
+}
+
+// OnAnyEvent 任意のイベントに対してハンドラを登録します。
+func (b *Bot) OnAnyEvent(h func(e string, rawPayload json.RawMessage)) {
+	for _, e := range event.AllEvents {
+		b.OnEvent(e, func(rawPayload json.RawMessage) {
+			h(e, rawPayload)
+		})
+	}
 }
 
 // makeDecoder is a utility function to be used with (*Bot).OnEvent.


### PR DESCRIPTION
任意のイベントを受け取るハンドラ登録関数を実装しました。

OnAnyEvent自体は自前で実装してもいいのですが、AllEventsをtraq-ws-bot側で持っていてくれると嬉しいので併せて定義しました。
